### PR TITLE
it should depend on MomentAsset

### DIFF
--- a/MomentLanguageAsset.php
+++ b/MomentLanguageAsset.php
@@ -11,6 +11,16 @@ use yii\web\View;
  */
 class MomentLanguageAsset extends AssetBundle
 {
+    /**
+     * @inheritdoc
+     */
+    public $depends = [
+        'omnilight\assets\MomentAsset'
+    ];
+
+    /**
+     * @inheritdoc
+     */
     public $sourcePath = '@bower/moment/locale';
     /**
      * @var string|null When null, language will be equal for current locale of the application


### PR DESCRIPTION
it should depend on MomentAsset to ensure that Moment is loaded first, sometimes this does not happen, even if you define them in correct order in dependency tree
